### PR TITLE
Persist current tab across sessions

### DIFF
--- a/src/main/java/net/technicpack/launcher/LauncherMain.java
+++ b/src/main/java/net/technicpack/launcher/LauncherMain.java
@@ -25,6 +25,7 @@ import net.technicpack.launcher.io.*;
 import net.technicpack.launcher.settings.migration.IMigrator;
 import net.technicpack.launcher.settings.migration.InitialV3Migrator;
 import net.technicpack.launcher.ui.InstallerFrame;
+import net.technicpack.launcher.ui.components.IInfoPanelListener;
 import net.technicpack.launcher.ui.components.discover.DiscoverInfoPanel;
 import net.technicpack.launcher.ui.components.modpacks.ModpackSelector;
 import net.technicpack.launchercore.auth.IAuthListener;
@@ -241,13 +242,27 @@ public class LauncherMain {
         selector.setBorder(BorderFactory.createEmptyBorder());
         userModel.addAuthListener(selector);
 
-        DiscoverInfoPanel discoverInfoPanel = new DiscoverInfoPanel(resources, startupParameters.getDiscoverUrl(), platform, splash);
+        IInfoPanelListener infoPanelListener = new IInfoPanelListener() {
+            @Override
+            public void panelReady(JPanel panel) {
+                if (splash.isValid()) {
+                    EventQueue.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            splash.dispose();
+                        }
+                    });
+                }
+            }
+        };
+
+        DiscoverInfoPanel discoverInfoPanel = new DiscoverInfoPanel(resources, startupParameters.getDiscoverUrl(), platform, infoPanelListener);
 
         MinecraftLauncher launcher = new MinecraftLauncher(platform, directories, userModel, settings.getClientId());
         ModpackInstaller modpackInstaller = new ModpackInstaller(platform, settings.getClientId());
         Installer installer = new Installer(startupParameters, mirrorStore, directories, modpackInstaller, launcher, settings, iconMapper);
 
-        LauncherFrame frame = new LauncherFrame(resources, skinRepo, userModel, settings, selector, iconRepo, logoRepo, backgroundRepo, installer, avatarRepo, platform, directories, packStore, startupParameters, discoverInfoPanel);
+        LauncherFrame frame = new LauncherFrame(resources, skinRepo, userModel, settings, selector, iconRepo, logoRepo, backgroundRepo, installer, avatarRepo, platform, directories, packStore, startupParameters, discoverInfoPanel, infoPanelListener);
         userModel.addAuthListener(frame);
 
         LoginFrame login = new LoginFrame(resources, settings, userModel, skinRepo);

--- a/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
+++ b/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
@@ -19,7 +19,6 @@
 package net.technicpack.launcher.settings;
 
 import net.technicpack.launchercore.util.LaunchAction;
-import net.technicpack.utilslib.OperatingSystem;
 import net.technicpack.utilslib.Utils;
 import org.apache.commons.io.FileUtils;
 
@@ -43,9 +42,13 @@ public class TechnicSettings {
     private String clientId = UUID.randomUUID().toString();
     private String directory;
     private String javaArgs;
+    private String currentTab;
     private int latestNewsArticle;
 
     private String launcherSettingsVersion = "0";
+
+    public String getCurrentTab() { return this.currentTab; }
+    public void setCurrentTab(String currentTab) { this.currentTab = currentTab; }
 
     public File getFilePath() { return this.settingsFile; }
     public void setFilePath(File settingsFile) {

--- a/src/main/java/net/technicpack/launcher/ui/components/IInfoPanelListener.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/IInfoPanelListener.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of The Technic Launcher Version 3.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * The Technic Launcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Technic Launcher  is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Technic Launcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launcher.ui.components;
+
+import javax.swing.*;
+
+public interface IInfoPanelListener {
+    void panelReady(JPanel panel);
+}

--- a/src/main/java/net/technicpack/launcher/ui/components/InfoPanelReadyDetector.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/InfoPanelReadyDetector.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of The Technic Launcher Version 3.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * The Technic Launcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Technic Launcher  is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Technic Launcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launcher.ui.components;
+
+import javax.swing.*;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
+
+public class InfoPanelReadyDetector implements HierarchyListener {
+    private IInfoPanelListener listener;
+
+    public InfoPanelReadyDetector(IInfoPanelListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void hierarchyChanged(HierarchyEvent e) {
+        if ((HierarchyEvent.SHOWING_CHANGED & e.getChangeFlags()) != 0 && e.getComponent().isShowing()) {
+            JPanel panel = (JPanel)e.getComponent();
+            listener.panelReady(panel);
+            panel.removeHierarchyListener(this);
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launcher/ui/components/discover/DiscoverInfoPanel.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/discover/DiscoverInfoPanel.java
@@ -18,13 +18,11 @@
 
 package net.technicpack.launcher.ui.components.discover;
 
+import net.technicpack.launcher.ui.components.IInfoPanelListener;
 import net.technicpack.platform.http.HttpPlatformApi;
-import net.technicpack.ui.controls.installation.*;
 import net.technicpack.ui.lang.ResourceLoader;
 import net.technicpack.ui.controls.TiledBackground;
-import org.w3c.dom.Document;
 import org.xhtmlrenderer.event.DocumentListener;
-import org.xhtmlrenderer.resource.ImageResource;
 import org.xhtmlrenderer.simple.XHTMLPanel;
 import org.xhtmlrenderer.swing.DelegatingUserAgent;
 import org.xhtmlrenderer.swing.FSMouseListener;
@@ -32,14 +30,12 @@ import org.xhtmlrenderer.swing.ImageResourceLoader;
 import org.xhtmlrenderer.swing.SwingReplacedElementFactory;
 
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
-public class DiscoverInfoPanel extends TiledBackground {
+public class DiscoverInfoPanel extends TiledBackground  {
 
     final private XHTMLPanel panel;
 
-    public DiscoverInfoPanel(ResourceLoader loader, String discoverUrl, HttpPlatformApi platform, final net.technicpack.ui.controls.installation.SplashScreen splash) {
+    public DiscoverInfoPanel(ResourceLoader loader, String discoverUrl, HttpPlatformApi platform, final IInfoPanelListener infoPanelListener) {
         super(loader.getImage("background_repeat2.png"));
 
         if (discoverUrl == null)
@@ -51,6 +47,7 @@ public class DiscoverInfoPanel extends TiledBackground {
         this.panel = new XHTMLPanel();
         panel.setFont(loader.getFont(ResourceLoader.FONT_OPENSANS, 16));
         panel.setDefaultFontFromComponent(true);
+        final DiscoverInfoPanel infopanel = this;
         panel.addDocumentListener(new DocumentListener() {
             @Override
             public void documentStarted() {
@@ -58,9 +55,7 @@ public class DiscoverInfoPanel extends TiledBackground {
             }
 
             @Override
-            public void documentLoaded() {
-                splash.dispose();
-            }
+            public void documentLoaded() { infoPanelListener.panelReady(infopanel); }
 
             @Override
             public void onLayoutException(Throwable throwable) {

--- a/src/main/java/net/technicpack/launcher/ui/components/modpacks/ModpackInfoPanel.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/modpacks/ModpackInfoPanel.java
@@ -18,6 +18,8 @@
 
 package net.technicpack.launcher.ui.components.modpacks;
 
+import net.technicpack.launcher.ui.components.IInfoPanelListener;
+import net.technicpack.launcher.ui.components.InfoPanelReadyDetector;
 import net.technicpack.ui.controls.RoundedButton;
 import net.technicpack.ui.controls.TiledBackground;
 import net.technicpack.ui.lang.ResourceLoader;
@@ -53,13 +55,14 @@ public class ModpackInfoPanel extends JPanel implements IImageJobListener<Modpac
 
     private ModpackModel modpack;
 
-    public ModpackInfoPanel(ResourceLoader loader, ImageRepository<ModpackModel> iconRepo, ImageRepository<ModpackModel> logoRepo, ImageRepository<ModpackModel> backgroundRepo, ImageRepository<AuthorshipInfo> avatarRepo, ActionListener modpackOptionsListener, ActionListener modpackRefreshListener) {
+    public ModpackInfoPanel(ResourceLoader loader, ImageRepository<ModpackModel> iconRepo, ImageRepository<ModpackModel> logoRepo, ImageRepository<ModpackModel> backgroundRepo, ImageRepository<AuthorshipInfo> avatarRepo, ActionListener modpackOptionsListener, ActionListener modpackRefreshListener, IInfoPanelListener listener) {
         this.resources  = loader;
         this.backgroundRepo = backgroundRepo;
         this.avatarRepo = avatarRepo;
         this.modpackRefreshListener = modpackRefreshListener;
 
         initComponents(iconRepo, logoRepo, modpackOptionsListener);
+        this.addHierarchyListener(new InfoPanelReadyDetector(listener));
     }
 
     public void setModpack(ModpackModel modpack) {

--- a/src/main/java/net/technicpack/launcher/ui/components/news/NewsInfoPanel.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/news/NewsInfoPanel.java
@@ -18,6 +18,8 @@
 
 package net.technicpack.launcher.ui.components.news;
 
+import net.technicpack.launcher.ui.components.IInfoPanelListener;
+import net.technicpack.launcher.ui.components.InfoPanelReadyDetector;
 import net.technicpack.ui.lang.ResourceLoader;
 import net.technicpack.launcher.ui.LauncherFrame;
 import net.technicpack.ui.controls.RoundedButton;
@@ -46,12 +48,13 @@ public class NewsInfoPanel extends JPanel implements PropertyChangeListener {
 
     private String url = "";
 
-    public NewsInfoPanel(ResourceLoader resources, ImageRepository<AuthorshipInfo> avatarRepo) {
+    public NewsInfoPanel(ResourceLoader resources, ImageRepository<AuthorshipInfo> avatarRepo, IInfoPanelListener listener) {
 
         this.resources = resources;
         this.avatarRepo = avatarRepo;
 
         initComponents();
+        this.addHierarchyListener(new InfoPanelReadyDetector(listener));
     }
 
     public void setArticle(NewsArticle article) {


### PR DESCRIPTION
Make changes necessary to save the current tab in the settings file every time a new one is selected, then read that on launch.
Had to make sure all tabs would now dispose of splash screen.

It looks like IDEA cleaned up some unused imports

Note:  This change became much larger than intended.  I am willing to make any changes you may require to make the patch conform to your vision.
