### PR TITLE
Use user defined java args.

### DIFF
--- a/src/main/java/net/technicpack/launcher/launch/Installer.java
+++ b/src/main/java/net/technicpack/launcher/launch/Installer.java
@@ -132,7 +132,7 @@ public class Installer {
                         } else
                             launcherUnhider = null;
 
-                        LaunchOptions options = new LaunchOptions(pack.getDisplayName(), packIconMapper.getImageLocation(pack).getAbsolutePath(), startupParameters.getWidth(), startupParameters.getHeight(), startupParameters.getFullscreen());
+                        LaunchOptions options = new LaunchOptions(pack.getDisplayName(), packIconMapper.getImageLocation(pack).getAbsolutePath(), startupParameters.getWidth(), startupParameters.getHeight(), startupParameters.getFullscreen(), settings.getJavaArgs());
                         launcher.launch(pack, memory, options, launcherUnhider, version);
 
                         if (launchAction == null || launchAction == LaunchAction.HIDE) {


### PR DESCRIPTION
Code to actually use the java args specified by the user in the Launcher Options.  The user can enter one option per line, all on one line, or a combination of both.

Corresponding pull request in MinecraftCore as well.
