### PR TITLE
Add an upper bound of JRE 1.8.0 to Launch4J's JRE detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,7 @@
 									</classPath>
 									<jre>
 										<minVersion>1.5.0</minVersion>
+										<maxVersion>1.8.0</maxVersion>
 										<opts><opt>-Djava.net.preferIPv4Stack=true</opt><opt>-Dawt.useSystemAAFontSettings=lcd</opt><opt>-Dswing.aatext=true</opt></opts>
 									</jre>
 									<icon>${basedir}/src/main/resources/exe/icon.ico</icon>


### PR DESCRIPTION
Fixes issue where Launch4J would detect and use Java 10+ then promptly crash because of incompatible AWT APIs