### PR TITLE
trim outer whitespace from search requests

### DIFF
--- a/src/main/java/net/technicpack/launcher/ui/components/modpacks/ModpackSelector.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/modpacks/ModpackSelector.java
@@ -503,9 +503,9 @@ public class ModpackSelector extends TintablePanel implements IModpackContainer,
         currentSearchTimer = new Timer(500, new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                String localSearchTag = searchText;
+                String localSearchTag = searchText.trim();
 
-                String localSearchUrl = searchText;
+                String localSearchUrl = searchText.trim();
                 if (!localSearchUrl.startsWith("http://") && !localSearchUrl.startsWith("https://"))
                     localSearchUrl = "http://" + localSearchTag;
 


### PR DESCRIPTION
No more bad api errors when someone copy and pastes a link into the search bar with a few extra spaces.