### PR TITLE
Added a notice at the top of logs when they're rotated due to the start of a new day while the launcher is running

### DIFF
--- a/src/main/java/net/technicpack/launcher/LauncherMain.java
+++ b/src/main/java/net/technicpack/launcher/LauncherMain.java
@@ -99,6 +99,8 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -217,7 +219,7 @@ public class LauncherMain {
             logDirectory.mkdir();
         }
         File logs = new File(logDirectory, "techniclauncher_%D.log");
-        RotatingFileHandler fileHandler = new RotatingFileHandler(logs.getPath());
+        RotatingFileHandler fileHandler = new RotatingFileHandler(logs.getPath(), buildNumber.getBuildNumber());
 
         fileHandler.setFormatter(new BuildLogFormatter(buildNumber.getBuildNumber()));
 

--- a/src/main/java/net/technicpack/launcher/LauncherMain.java
+++ b/src/main/java/net/technicpack/launcher/LauncherMain.java
@@ -99,8 +99,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;


### PR DESCRIPTION
Added a notice to the top of a new logs when the day changes and the logs are rotated while the launcher is running. This way you can easily know that a log didn't just randomly start in the middle.
![image](https://user-images.githubusercontent.com/8279453/86524146-e5c26f80-be44-11ea-8d43-bf873150b752.png)
