### PR TITLE
Fix exception when moving installation

### DIFF
--- a/src/main/java/net/technicpack/launcher/ui/InstallerFrame.java
+++ b/src/main/java/net/technicpack/launcher/ui/InstallerFrame.java
@@ -182,9 +182,11 @@ public class InstallerFrame extends DraggableFrame implements IRelocalizableReso
                             newRoot.mkdirs();
 
                         FileUtils.copyDirectory(oldRoot, newRoot);
+                        LauncherMain.setupLogFile(new TechnicLauncherDirectories(newRoot));
+                        Utils.getLogger().info("Log file location changed");
                         FileUtils.deleteDirectory(oldRoot);
                     } catch (IOException ex) {
-                        Utils.getLogger().log(Level.SEVERE, "Copying install to new directory failed: ",ex);
+                        Utils.getLogger().log(Level.SEVERE, "Copying install to new directory failed: ", ex);
                     }
                 }
 


### PR DESCRIPTION
Closes #197

I'd rather not make `LauncherMain::setupLogFile` a public method, but I don't really see a choice without refactoring or using reflection.

Let me know what you think!