### PR TITLE
Strip -Xmx flag from custom java args

### DIFF
--- a/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
+++ b/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
@@ -186,6 +186,7 @@ public class TechnicSettings implements ILaunchOptions {
         if (args != null && args.equalsIgnoreCase(DEFAULT_JAVA_ARGS)) {
             javaArgs = null;
         } else {
+            args = args.replaceAll("-Xmx\d[kKmMgG]? ", "");
             javaArgs = args;
         }
     }

--- a/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
+++ b/src/main/java/net/technicpack/launcher/settings/TechnicSettings.java
@@ -186,7 +186,7 @@ public class TechnicSettings implements ILaunchOptions {
         if (args != null && args.equalsIgnoreCase(DEFAULT_JAVA_ARGS)) {
             javaArgs = null;
         } else {
-            args = args.replaceAll("-Xmx\d[kKmMgG]? ", "");
+            args = args.replaceAll("-Xmx\d+[kKmMgG]? ", "");
             javaArgs = args;
         }
     }


### PR DESCRIPTION
A user is able to set an -Xmx flag in the java args box, which could override the memory selector dropdown. This regex replace will automatically strip any -Xmx flag before setting.

Formats include but are not limited to:
-Xmx1024
-Xmx2G
-Xmx512k