### PR TITLE
Allow Launch4j to use java from the JAVA_HOME or PATH and allow Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,8 +306,9 @@
                                         <preCp>anything</preCp>
                                     </classPath>
                                     <jre>
+                                        <path>%JAVA_HOME%;%PATH%</path>
                                         <minVersion>1.8.0</minVersion>
-                                        <maxVersion>1.8.0_999</maxVersion>
+                                        <maxVersion>17</maxVersion>
                                         <opts>
                                             <opt>-Djava.net.preferIPv4Stack=true</opt>
                                             <opt>-Dawt.useSystemAAFontSettings=lcd</opt>


### PR DESCRIPTION
This fixes the below error on some systems
![2022-08-07_14-45-16](https://user-images.githubusercontent.com/5401186/183294558-899c2804-7695-4c46-9bf6-b6f419b2019e.png)
