### PR TITLE
feat: add more memory options in dialog box

### DIFF
--- a/src/main/java/net/technicpack/utilslib/Memory.java
+++ b/src/main/java/net/technicpack/utilslib/Memory.java
@@ -46,6 +46,14 @@ public class Memory {
             (new Memory(14336, "14 GB", 16)),
             (new Memory(15360, "15 GB", 17)),
             (new Memory(16384, "16 GB", 18)),
+            (new Memory(17408, "17 GB", 21)),
+            (new Memory(18432, "18 GB", 22)),
+            (new Memory(19456, "19 GB", 23)),
+            (new Memory(20480, "20 GB", 24)),
+            (new Memory(21504, "21 GB", 25)),
+            (new Memory(22528, "22 GB", 26)),
+            (new Memory(23552, "23 GB", 27)),
+            (new Memory(24576, "24 GB", 28)),
     };
     public static final Memory DEFAULT_MEM = memoryOptions[2];
     public static final int MAX_32_BIT_MEMORY = 1024;


### PR DESCRIPTION
By popular request (and by that I mean the request of one of my friends), at least one modpack has the ability to demand 16 GB of memory very easily. Adding more options should allow users to use more complex modpacks.