### PR TITLE
Fix #193 on Windows

### DIFF
--- a/src/main/java/net/technicpack/utilslib/DesktopUtils.java
+++ b/src/main/java/net/technicpack/utilslib/DesktopUtils.java
@@ -38,6 +38,8 @@ public class DesktopUtils {
                 // But xdg-open seems to work more reliably - so if on Linux (check first), we prefer using that.
                 if(OperatingSystem.getOperatingSystem() == OperatingSystem.LINUX)
                     Runtime.getRuntime().exec(new String[]{"xdg-open", url});
+                else if (OperatingSystem.getOperatingSystem() == OperatingSystem.WINDOWS)
+                    Runtime.getRuntime().exec(new String[]{"explorer", url});
                 else if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE))
                     Desktop.getDesktop().browse(new URI(url));
                 else if(OperatingSystem.getOperatingSystem() == OperatingSystem.OSX)


### PR DESCRIPTION
When launching Microsoft login, the entire UI freezes. It's not known if this issue appears on Windows, but let's patch it just in case.

This should fully close #193 (but the BSDs sometimes don't have `xdg-open`, so that might be an issue in the future if the launcher is packaged on that system.)

(For more context, see #193.)