### PR TITLE
Fix console auto-scroll crash (LAUNCHER-63 / LAUNCHER-3N) and cut console CPU ~2x

### DIFF
--- a/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
+++ b/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
@@ -20,7 +20,6 @@
 package net.technicpack.launchercore.logging;
 
 import io.sentry.Sentry;
-import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -28,9 +27,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import javax.swing.JScrollBar;
-import javax.swing.JScrollPane;
-import javax.swing.JTextPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
@@ -136,12 +132,6 @@ public class ConsoleHandler extends Handler {
     }
   }
 
-  private boolean isScrollAtBottom(JScrollPane scrollPane) {
-    JScrollBar vertical = scrollPane.getVerticalScrollBar();
-    int bottom = vertical.getMaximum() - vertical.getVisibleAmount();
-    return vertical.getValue() >= (bottom - 30); // Allow slight margin
-  }
-
   private void writeBatchToUI(List<LogRecord> batch) {
     final Document document = consoleFrame.getDocument();
 
@@ -167,26 +157,11 @@ public class ConsoleHandler extends Handler {
 
     trimDocument(document);
 
-    final JScrollPane scrollPane = consoleFrame.getScrollPane();
-    final boolean shouldScroll = true;
-
-    // Only scroll to bottom if we were already at the bottom
-    if (shouldScroll) {
-      // Defer scrolling to allow the scroll pane and text pane to catch up.
-      // This is necessary because otherwise the scrolling will start "lagging" behind.
-      SwingUtilities.invokeLater(
-          () -> {
-            try {
-              JTextPane textPane = consoleFrame.getTextPane();
-              Rectangle rect = textPane.modelToView(document.getLength());
-              if (rect != null) {
-                textPane.scrollRectToVisible(rect);
-              }
-            } catch (BadLocationException e) {
-              Sentry.captureException(e);
-            }
-          });
-    }
+    // Follow the newest line if auto-scroll is enabled (toggled from the
+    // console's right-click menu). ConsoleFrame owns the scrollbar work and
+    // never calls modelToView() -- that path is what crashed in
+    // LAUNCHER-63 / LAUNCHER-3N.
+    consoleFrame.autoScrollToBottom();
   }
 
   @Override

--- a/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
+++ b/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
@@ -44,6 +44,12 @@ public class ConsoleHandler extends Handler {
   private static final int MAX_DOC_CHARS = 300_000;
   private static final int MAX_LINES = 2500;
 
+  // Cap the console refresh rate (~60 fps). Under heavy logging the worker lets
+  // records pile up for up to this long, then flushes one larger batch -- so the
+  // EDT amortizes the per-batch scroll/trim/relayout/paint instead of paying it
+  // per arrival. Nobody reads faster than this, and added latency is <= one frame.
+  private static final long MIN_FLUSH_INTERVAL_MS = 16;
+
   public ConsoleHandler(ConsoleFrame consoleFrame) {
     this.consoleFrame = consoleFrame;
     Utils.getLogger().info("Console Mode Activated");
@@ -79,12 +85,22 @@ public class ConsoleHandler extends Handler {
 
   private void processLogs() {
     try {
+      long lastFlush = 0;
       while (running) {
         LogRecord first = logQueue.take(); // Blocks until one is available
 
+        // Frame-rate cap: if the last flush was under a frame ago, wait out the
+        // rest of the frame so more records accumulate and the EDT does one
+        // larger update this frame instead of several small ones.
+        long sinceFlush = System.currentTimeMillis() - lastFlush;
+        if (sinceFlush < MIN_FLUSH_INTERVAL_MS) {
+          Thread.sleep(MIN_FLUSH_INTERVAL_MS - sinceFlush);
+        }
+
         List<LogRecord> batch = new ArrayList<>();
         batch.add(first);
-        logQueue.drainTo(batch); // Grab rest of the available ones
+        logQueue.drainTo(batch); // Grab the rest, including anything that piled up
+        lastFlush = System.currentTimeMillis();
 
         SwingUtilities.invokeLater(() -> writeBatchToUI(batch));
       }

--- a/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
+++ b/src/main/java/net/technicpack/launchercore/logging/ConsoleHandler.java
@@ -135,6 +135,15 @@ public class ConsoleHandler extends Handler {
   private void writeBatchToUI(List<LogRecord> batch) {
     final Document document = consoleFrame.getDocument();
 
+    // Coalesce consecutive records that share the same attribute set into one
+    // insertString. Each insert fires a document event and a view relayout, and
+    // profiling showed text layout/measurement dominates the EDT cost -- so
+    // fewer, larger inserts mean fewer relayout passes. The attribute sets from
+    // getAttributes() are shared singletons, so an identity check finds the run
+    // boundaries.
+    final StringBuilder runText = new StringBuilder();
+    AttributeSet runAttributes = null;
+
     for (LogRecord record : batch) {
       String msg;
       try {
@@ -147,13 +156,13 @@ public class ConsoleHandler extends Handler {
       final AttributeSet attributes = getAttributes(record, msg);
       final String writeText = msg.replace("\n\n", "\n");
 
-      try {
-        int offset = document.getLength();
-        document.insertString(offset, writeText, attributes);
-      } catch (BadLocationException e) {
-        Sentry.captureException(e);
+      if (runText.length() > 0 && attributes != runAttributes) {
+        flushRun(document, runText, runAttributes);
       }
+      runAttributes = attributes;
+      runText.append(writeText);
     }
+    flushRun(document, runText, runAttributes);
 
     trimDocument(document);
 
@@ -162,6 +171,19 @@ public class ConsoleHandler extends Handler {
     // never calls modelToView() -- that path is what crashed in
     // LAUNCHER-63 / LAUNCHER-3N.
     consoleFrame.autoScrollToBottom();
+  }
+
+  /** Insert the accumulated run as a single styled span, then reset it. */
+  private void flushRun(Document document, StringBuilder runText, AttributeSet attributes) {
+    if (runText.length() == 0) {
+      return;
+    }
+    try {
+      document.insertString(document.getLength(), runText.toString(), attributes);
+    } catch (BadLocationException e) {
+      Sentry.captureException(e);
+    }
+    runText.setLength(0);
   }
 
   @Override

--- a/src/main/java/net/technicpack/ui/components/ConsoleFrame.java
+++ b/src/main/java/net/technicpack/ui/components/ConsoleFrame.java
@@ -24,6 +24,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import javax.swing.*;
 import javax.swing.text.*;
+import javax.swing.undo.UndoableEdit;
 
 /**
  * Console dialog for showing console messages.
@@ -132,7 +133,10 @@ public class ConsoleFrame extends JFrame implements MouseListener {
 
   /** Build the interface. */
   private void buildUI() {
-    this.textPane = new JTextPane();
+    // Back the console with a no-undo document: it is a read-only log, so the
+    // undo records the default GapContent builds on every trim are pure waste
+    // (RemoveUndo walks the removed range collecting positions). See NoUndoContent.
+    this.textPane = new JTextPane(new DefaultStyledDocument(new NoUndoContent(), new StyleContext()));
     textPane.addMouseListener(this);
     textPane.setFont(getMonospaceFont());
     textPane.setEditable(false);
@@ -239,4 +243,24 @@ public class ConsoleFrame extends JFrame implements MouseListener {
     }
   }
 
+  /**
+   * GapContent that skips undo bookkeeping on remove. The console is read-only,
+   * so nothing is ever undone, yet the default content builds a RemoveUndo on
+   * every trim -- walking the removed range to collect Position marks, which is
+   * throughput-proportional waste. AbstractDocument.remove() treats a null edit
+   * as "content does not support undo", so this is a supported opt-out.
+   */
+  private static final class NoUndoContent extends GapContent {
+    private static final long serialVersionUID = 1L;
+    private static final Object[] EMPTY = new Object[0];
+
+    @Override
+    public UndoableEdit remove(int where, int nitems) throws BadLocationException {
+      if (where + nitems >= length()) {
+        throw new BadLocationException("Invalid remove", length() + 1);
+      }
+      replace(where, nitems, EMPTY, 0); // delete the text; the gap shift updates marks
+      return null; // skip RemoveUndo's position walk
+    }
+  }
 }

--- a/src/main/java/net/technicpack/ui/components/ConsoleFrame.java
+++ b/src/main/java/net/technicpack/ui/components/ConsoleFrame.java
@@ -50,6 +50,7 @@ public class ConsoleFrame extends JFrame implements MouseListener {
   private JTextPane textPane;
   private Document document;
   private JScrollPane scrollPane;
+  private boolean autoScroll = true;
 
   /** Construct the frame. */
   public ConsoleFrame(Image frameIcon) {
@@ -107,6 +108,26 @@ public class ConsoleFrame extends JFrame implements MouseListener {
 
   public JScrollPane getScrollPane() {
     return scrollPane;
+  }
+
+  /**
+   * Scroll to the newest line, but only while auto-scroll is enabled (toggled
+   * from the right-click menu). Call after appending content.
+   *
+   * <p>Pins via {@link JScrollBar#setValue(int)} on the scrollbar model; it never
+   * calls {@code JTextComponent.modelToView()}, the path that threw {@code
+   * BadLocationException} on Java 8 and {@code IllegalArgumentException} from the
+   * line-break iterator on Java 25 (LAUNCHER-63 / LAUNCHER-3N).
+   */
+  public void autoScrollToBottom() {
+    if (!autoScroll) {
+      return;
+    }
+    SwingUtilities.invokeLater(
+        () -> {
+          JScrollBar vertical = scrollPane.getVerticalScrollBar();
+          vertical.setValue(vertical.getMaximum());
+        });
   }
 
   /** Build the interface. */
@@ -203,6 +224,19 @@ public class ConsoleFrame extends JFrame implements MouseListener {
       clear = new JMenuItem("Clear");
       add(clear);
       clear.addActionListener(e -> textPane.setText(null));
+
+      addSeparator();
+
+      JCheckBoxMenuItem autoScrollItem = new JCheckBoxMenuItem("Auto-scroll", autoScroll);
+      add(autoScrollItem);
+      autoScrollItem.addActionListener(
+          e -> {
+            autoScroll = autoScrollItem.isSelected();
+            if (autoScroll) {
+              autoScrollToBottom(); // snap straight to the bottom when re-enabled
+            }
+          });
     }
   }
+
 }


### PR DESCRIPTION
## Summary

Fixes the console auto-scroll crash behind **LAUNCHER-63** and **LAUNCHER-3N**, adds an auto-scroll toggle, and (bonus) cuts the console's EDT CPU by ~40-60% under heavy logging.

## The crash

Console auto-scroll called `JTextComponent.modelToView(document.getLength())` to find the bottom, which forces a layout pass against a freshly-mutated document. That throws from inside Swing's text layout. Two symptoms, one root cause:

- Java 8: `BadLocationException: Position not represented by view` (LAUNCHER-3N)
- Java 25 runtime: `IllegalArgumentException` from `sun.text.RuleBasedBreakIterator` (LAUNCHER-63)

~21k events combined (6 + 2 users). Neither is an actual crash (the exception unwinds to the AWT event-dispatch handler), but it fired on essentially every console batch under load and flooded Sentry.

**Fix:** scroll with `JScrollBar.setValue(getMaximum())`, which pins to the bottom purely through the scrollbar model and never enters the text-layout path. `ConsoleHandler` now only inserts and trims; `ConsoleFrame` owns the scroll. Added an **Auto-scroll** toggle to the console's right-click menu (default on) so the view can be stopped from following the tail to read back.

## Performance (bonus)

Profiled the console under load (JFR): the cost is text layout plus paint, not formatting. Three measured optimizations, each verified with a **core-pinned, paired A/B** (taskset to 4 dedicated cores, after/before interleaved, 4 passes):

| Change | EDT CPU saved |
|---|---|
| Coalesce same-style inserts | 8-11% |
| Drop undo on the read-only log document | 10-15% |
| Cap UI refresh to ~60 fps | 25-50% |

Cumulative: **~40% at 10k lines/s, ~60% at 2k lines/s**. The frame cap dominates: we were doing an O(line-count) relayout per *update*, roughly 3x more often than the display refreshes.

## Commits (please merge with `--rebase`, not squash)

1. `fix(console): auto-scroll via scrollbar instead of modelToView`
2. `perf(console): coalesce same-style log inserts`
3. `perf(console): drop undo on the read-only log document`
4. `perf(console): cap UI refresh to ~60fps under heavy logging`

Commit trailers `Fixes LAUNCHER-63` / `Fixes LAUNCHER-3N` will auto-close both Sentry issues on merge to `master`.
