### PR TITLE
feat(sentry): set release and register it at promote time

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -35,6 +35,10 @@ jobs:
     steps:
       - name: Checkout master
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so the Sentry release can associate the commit range
+          # (previous release head .. current head) for commit-trailer auto-resolve.
+          fetch-depth: 0
 
       - name: Validate Secrets
         env:
@@ -336,6 +340,22 @@ jobs:
             --title "${title}" \
             --notes-file "${notes_file}" \
             "${JAR_PATH}" "${EXE_PATH}" "${OSX_PATH}"
+
+      - name: Register Sentry Release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        continue-on-error: true # release tracking must never block shipping a build to users
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.technicpack.net/
+          SENTRY_ORG: technic
+          SENTRY_PROJECT: launcher
+        with:
+          # Dotted semver so Sentry orders builds numerically; must match the string the
+          # launcher sets at runtime in LauncherMain.resolveSentryRelease().
+          version: launcher@${{ env.LAUNCHER_MAJOR }}.${{ steps.artifact.outputs.build_number }}
+          set_commits: auto # falls back to the local git tree when no repo integration exists
+          finalize: true
+          ignore_missing: true # the first release has no prior baseline -- don't fail on it
 
       - name: Roll Over CHANGELOG
         if: steps.notes.outputs.notes_source == 'changelog'

--- a/src/main/java/net/technicpack/launcher/LauncherMain.java
+++ b/src/main/java/net/technicpack/launcher/LauncherMain.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -119,6 +120,7 @@ import net.technicpack.ui.lang.ResourceLoader;
 import net.technicpack.utilslib.JavaUtils;
 import net.technicpack.utilslib.OperatingSystem;
 import net.technicpack.utilslib.Utils;
+import org.apache.commons.io.IOUtils;
 
 public class LauncherMain {
 
@@ -142,11 +144,50 @@ public class LauncherMain {
   private static IBuildNumber buildNumber;
   private static RotatingFileHandler currentFileHandler;
 
+  /**
+   * Resolve the Sentry release for this run: {@code launcher@4.0.<build>}, or {@code null} for
+   * dev/source builds. Reads the build-baked {@code version} resource straight off the classpath
+   * (the same file {@link VersionFileBuildNumber} reads later) because the release has to be set at
+   * {@link Sentry#init} time, before the {@link ResourceLoader} that normally serves it exists.
+   *
+   * <p>The dot form ({@code 4.0.<build>}) is deliberate: Sentry only treats {@code package@version}
+   * as semver when the version is dotted, and semver ordering is what lets an event from an older
+   * build be recognized as older instead of reopening a resolved issue. It intentionally differs
+   * from the git tag ({@code v4.0-<build>}); it only has to match the release promote.yml creates.
+   */
+  private static String resolveSentryRelease() {
+    try (InputStream versionStream =
+        LauncherMain.class.getResourceAsStream("/net/technicpack/launcher/resources/version")) {
+      if (versionStream == null) {
+        return null;
+      }
+      String build = IOUtils.toString(versionStream, StandardCharsets.UTF_8).trim();
+      // Dev/IDE runs leave the literal ${buildNumber} placeholder; an unset BUILD_NUMBER bakes
+      // "0". Only a real, numbered build gets a release.
+      if (!build.matches("\\d+") || "0".equals(build)) {
+        return null;
+      }
+      return "launcher@4.0." + build;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
   public static void main(String[] argv) {
     // Initialize Sentry
     Sentry.init(
         options -> {
           options.setDsn("https://c9b34c6f367b5b4061a1bfdb8bde3ef7@sentry.technicpack.net/3");
+
+          // Tag events with the semver release so Sentry can order builds: this is what
+          // makes commit-trailer auto-resolve and regression detection work, and what stops
+          // an event from a straggler on an older build reopening a resolved issue. Null on
+          // dev/source builds, which correctly leaves the release unset.
+          String release = resolveSentryRelease();
+          if (release != null) {
+            options.setRelease(release);
+          }
+
           options.setTag(
               "launcherPath",
               LauncherMain.class.getProtectionDomain().getCodeSource().getLocation().getPath());


### PR DESCRIPTION
## What

Set up Sentry release tracking for the launcher:

- **Runtime:** `LauncherMain` reads the build-baked `/version` resource at
  `Sentry.init` and calls `options.setRelease("launcher@4.0.<build>")`. Dev
  and source builds (no numbered version) leave the release unset.
- **Promote:** `promote.yml` gains a SHA-pinned `getsentry/action-release`
  step that creates, associates commits with, and finalizes the matching
  release against the self-hosted instance. Checkout now uses
  `fetch-depth: 0` so the commit range is available.

The existing `buildNumber` tag is unchanged; the release is additive.

## Why

Two problems this fixes:

1. `Fixes LAUNCHER-N` commit trailers were inert. Sentry only auto-resolves
   an issue from a commit message when the commit is associated with a
   release, and the project had zero releases. Now the promote step registers
   the release with its commits, so trailers resolve issues going forward.
2. Manually-resolved issues reopened on stragglers. Without a release on
   events, Sentry cannot tell a pre-fix event from a post-fix one, so a user
   still on an old build reopened issues we had just resolved. With releases,
   Sentry orders builds and treats old-build events as older.

## Why the dotted `4.0.<build>` form (not the git tag `v4.0-<build>`)

Sentry only parses a release as semver when it is shaped
`package@major.minor.patch`. The dotted form (`launcher@4.0.1120`) parses as
semver, so Sentry orders builds numerically and reliably recognizes a
straggler's build as older. The git tag form (`launcher@4.0-1120`, hyphen +
two components) does not parse as semver and falls back to first-seen-date
ordering, which is exactly what lets a late event from an old build look
"newer" and reopen a resolved issue. The Sentry release string only has to be
internally consistent between the runtime (`LauncherMain`) and promote
(`promote.yml`), which it is; it deliberately differs from the git tag.

## Notes and caveats

- **Auth token scopes:** the existing `SENTRY_AUTH_TOKEN` secret must include
  `project:releases`. It already drives source-context upload, so it likely
  does; the step is `continue-on-error`, so if it lacks scope the promotion
  still ships and we see a warning rather than a failure.
- **First release does not backfill:** the first promote after this merges has
  no prior release as a baseline (`ignore_missing: true` handles that
  gracefully), so it will not retroactively resolve existing open issues. It
  works from the next fix forward.
- **No GitHub integration needed:** `set_commits: auto` falls back to the
  local git tree when no repo integration is configured in the self-hosted
  Sentry.
- **Never blocks a release:** the whole step is `continue-on-error`, matching
  the non-fatal spirit of the existing Discord-notify step.

## Verification

- `./gradlew spotlessCheck compileJava test` green locally.
- `promote.yml` validated as YAML; the four action inputs
  (`version`, `set_commits`, `finalize`, `ignore_missing`) confirmed present
  in `getsentry/action-release@v3.7.0`.
- The real release materializes on the next promote; afterwards
  `find_releases(technic/launcher)` should show `launcher@4.0.<build>` with
  commits attached.
