### PR TITLE
Offer keep-or-delete world saves choice when deleting a modpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ is added at the top.
 
 ## [Unreleased]
 
+### Added
+- Deleting a modpack now asks what you want to do with your world saves. If the pack has any, the confirmation offers **Delete everything**, **Keep world saves**, or **Cancel**: keeping them leaves the pack's `saves` folder on disk, and reinstalling the same pack later picks your worlds up again automatically. Packs without saves get the same yes/no confirmation as before. This applies to both delete buttons (the modpack page and the pack options dialog).
+
 ## [v4.0-1130] - 2026-07-05
 
 ### Changed

--- a/src/main/java/net/technicpack/launcher/ui/LauncherFrame.java
+++ b/src/main/java/net/technicpack/launcher/ui/LauncherFrame.java
@@ -30,6 +30,7 @@ import net.technicpack.launcher.io.LauncherFileSystem;
 import net.technicpack.launcher.launch.Installer;
 import net.technicpack.launcher.settings.StartupParameters;
 import net.technicpack.launcher.settings.TechnicSettings;
+import net.technicpack.launcher.ui.components.ModpackDeleteDialog;
 import net.technicpack.launcher.ui.components.ModpackOptionsDialog;
 import net.technicpack.launcher.ui.components.OptionsDialog;
 import net.technicpack.launcher.ui.components.discover.DiscoverInfoPanel;
@@ -592,13 +593,8 @@ public class LauncherFrame extends DraggableFrame implements IRelocalizableResou
         .getDeleteButton()
         .addActionListener(
             e -> {
-              if (JOptionPane.showConfirmDialog(
-                      LauncherFrame.this,
-                      resources.getString("modpackoptions.delete.confirmtext"),
-                      resources.getString("modpackoptions.delete.confirmtitle"),
-                      JOptionPane.YES_NO_OPTION)
-                  == JOptionPane.YES_OPTION) {
-                modpackSelector.getSelectedPack().delete();
+              if (ModpackDeleteDialog.confirmDelete(
+                  LauncherFrame.this, modpackSelector.getSelectedPack(), resources)) {
                 modpackSelector.forceRefresh();
               }
             });

--- a/src/main/java/net/technicpack/launcher/ui/components/ModpackDeleteDialog.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/ModpackDeleteDialog.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of The Technic Launcher Version 3.
+ * Copyright ©2015 Syndicate, LLC
+ *
+ * The Technic Launcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Technic Launcher  is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Technic Launcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launcher.ui.components;
+
+import java.awt.Component;
+import javax.swing.JOptionPane;
+import net.technicpack.launchercore.modpacks.ModpackModel;
+import net.technicpack.ui.lang.ResourceLoader;
+
+public final class ModpackDeleteDialog {
+
+  private static final int DELETE_EVERYTHING = 0;
+  private static final int KEEP_SAVES = 1;
+
+  private ModpackDeleteDialog() {}
+
+  /**
+   * Asks the user to confirm deleting the given pack and performs the deletion. Packs with world
+   * saves get a three-way choice (delete everything, keep the saves in place, cancel); packs
+   * without get a plain yes/no confirmation.
+   *
+   * @return true if the pack was deleted
+   */
+  public static boolean confirmDelete(
+      Component parent, ModpackModel modpack, ResourceLoader resources) {
+    if (modpack.hasWorldSaves()) {
+      Object[] options = {
+        resources.getString("modpackoptions.delete.deleteeverything"),
+        resources.getString("modpackoptions.delete.keepsaves"),
+        resources.getString("modpackoptions.delete.cancel"),
+      };
+      int result =
+          JOptionPane.showOptionDialog(
+              parent,
+              resources.getString("modpackoptions.delete.savestext"),
+              resources.getString("modpackoptions.delete.confirmtitle"),
+              JOptionPane.YES_NO_CANCEL_OPTION,
+              JOptionPane.WARNING_MESSAGE,
+              null,
+              options,
+              options[2]);
+
+      if (result == DELETE_EVERYTHING || result == KEEP_SAVES) {
+        modpack.delete(result == KEEP_SAVES);
+        return true;
+      }
+
+      // Cancel button, Esc or closing the dialog (CLOSED_OPTION)
+      return false;
+    }
+
+    int result =
+        JOptionPane.showConfirmDialog(
+            parent,
+            resources.getString("modpackoptions.delete.confirmtext"),
+            resources.getString("modpackoptions.delete.confirmtitle"),
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE);
+
+    if (result == JOptionPane.YES_OPTION) {
+      modpack.delete();
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/net/technicpack/launcher/ui/components/ModpackOptionsDialog.java
+++ b/src/main/java/net/technicpack/launcher/ui/components/ModpackOptionsDialog.java
@@ -125,15 +125,7 @@ public class ModpackOptionsDialog extends LauncherDialog {
   }
 
   protected void deletePack() {
-    int result =
-        JOptionPane.showConfirmDialog(
-            this,
-            resources.getString("modpackoptions.delete.confirmtext"),
-            resources.getString("modpackoptions.delete.confirmtitle"),
-            JOptionPane.YES_NO_OPTION,
-            JOptionPane.WARNING_MESSAGE);
-    if (result == JOptionPane.YES_OPTION) {
-      modpack.delete();
+    if (ModpackDeleteDialog.confirmDelete(this, modpack, resources)) {
       dispose();
     }
   }

--- a/src/main/java/net/technicpack/launchercore/modpacks/ModpackModel.java
+++ b/src/main/java/net/technicpack/launchercore/modpacks/ModpackModel.java
@@ -379,6 +379,16 @@ public class ModpackModel {
     return new File(installedDir, "saves");
   }
 
+  /** Whether this pack's saves directory exists and contains at least one entry. */
+  public boolean hasWorldSaves() {
+    File savesDir = getSavesDir();
+
+    if (savesDir == null || !savesDir.isDirectory()) return false;
+
+    String[] entries = savesDir.list();
+    return entries != null && entries.length > 0;
+  }
+
   public void initDirectories() {
     getBinDir().mkdirs();
     getModsDir().mkdirs();
@@ -497,11 +507,27 @@ public class ModpackModel {
   }
 
   public void delete() {
-    if (getInstalledDirectory() != null && getInstalledDirectory().exists()) {
-      try {
-        FileUtils.deleteDirectory(getInstalledDirectory());
-      } catch (IOException e) {
-        Utils.getLogger().log(Level.SEVERE, e.getMessage(), e);
+    delete(false);
+  }
+
+  /**
+   * Deletes this pack from disk and unregisters it from the pack store.
+   *
+   * @param keepSaves when true, the saves directory is left in place so a future reinstall of the
+   *     same pack picks the worlds back up
+   */
+  public void delete(boolean keepSaves) {
+    File installedDir = getInstalledDirectory();
+
+    if (installedDir != null && installedDir.exists()) {
+      if (keepSaves && getSavesDir().exists()) {
+        deleteChildrenExceptSaves(installedDir);
+      } else {
+        try {
+          FileUtils.deleteDirectory(installedDir);
+        } catch (IOException e) {
+          Utils.getLogger().log(Level.SEVERE, e.getMessage(), e);
+        }
       }
     }
 
@@ -517,5 +543,22 @@ public class ModpackModel {
     packStore.remove(getName());
     installedPack = null;
     installedDirectory = null;
+  }
+
+  private static void deleteChildrenExceptSaves(File installedDir) {
+    File[] children = installedDir.listFiles();
+
+    if (children == null) return;
+
+    for (File child : children) {
+      // Case-insensitive: on Windows/macOS a differently-cased "Saves" is the saves directory
+      if (child.getName().equalsIgnoreCase("saves")) continue;
+
+      try {
+        FileUtils.forceDelete(child);
+      } catch (IOException e) {
+        Utils.getLogger().log(Level.SEVERE, e.getMessage(), e);
+      }
+    }
   }
 }

--- a/src/main/resources/lang/UIText_en.properties
+++ b/src/main/resources/lang/UIText_en.properties
@@ -110,6 +110,10 @@ modpackoptions.move.errortitle          = Invalid Location
 modpackoptions.delete.text              = Delete Pack
 modpackoptions.delete.confirmtext       = Are you sure you want to remove this pack from your system?
 modpackoptions.delete.confirmtitle      = Delete Pack
+modpackoptions.delete.savestext         = Are you sure you want to remove this pack from your system?\n\nThis pack has world saves. Keeping them means your worlds will be restored if you ever reinstall this pack.
+modpackoptions.delete.deleteeverything  = Delete everything
+modpackoptions.delete.keepsaves         = Keep world saves
+modpackoptions.delete.cancel            = Cancel
 
 launcher.build.text     = Launcher Build 4.{0}
 

--- a/src/main/resources/lang/UIText_pt_BR.properties
+++ b/src/main/resources/lang/UIText_pt_BR.properties
@@ -71,6 +71,10 @@ modpackoptions.move.errortitle          = Local Invalido
 modpackoptions.delete.text              = Apagar ModPack
 modpackoptions.delete.confirmtext       = Tem certeza que quer remover este modpack do seu sistema?
 modpackoptions.delete.confirmtitle      = Apagar ModPack
+modpackoptions.delete.savestext         = Tem certeza que quer remover este modpack do seu sistema?\n\nEste modpack tem mundos salvos. Se você os mantiver, seus mundos voltam se um dia reinstalar este modpack.
+modpackoptions.delete.deleteeverything  = Apagar tudo
+modpackoptions.delete.keepsaves         = Manter os mundos
+modpackoptions.delete.cancel            = Cancelar
 
 launcher.build.text     = Versão do Inicializador 4.{0}
 

--- a/src/main/resources/lang/UIText_pt_PT.properties
+++ b/src/main/resources/lang/UIText_pt_PT.properties
@@ -74,6 +74,10 @@ modpackoptions.move.errortitle          = Localização inválida
 modpackoptions.delete.text              = Eliminar Pack
 modpackoptions.delete.confirmtext       = Tem a certeza que pretende remover este pack do seu sistema?
 modpackoptions.delete.confirmtitle      = Eliminar Pack
+modpackoptions.delete.savestext         = Tens a certeza que queres remover este pack do teu sistema?\n\nEste pack tem mundos guardados. Se os mantiveres, os teus mundos voltam se um dia voltares a instalar este pack.
+modpackoptions.delete.deleteeverything  = Eliminar tudo
+modpackoptions.delete.keepsaves         = Manter os mundos
+modpackoptions.delete.cancel            = Cancelar
 
 launcher.build.text     = Launcher Build 4.{0}
 

--- a/src/main/resources/lang/UIText_pt_PT.properties
+++ b/src/main/resources/lang/UIText_pt_PT.properties
@@ -65,14 +65,14 @@ modpackoptions.build.recommended    = Recomendada
 modpackoptions.build.latest         = Mais Recente
 
 modpackoptions.reinstall.text           = Reinstalar Pack
-modpackoptions.reinstall.confirmtext    = Tem a certeza que deseja fazer reset a este pack?
+modpackoptions.reinstall.confirmtext    = Tens a certeza que queres fazer reset a este pack?
 modpackoptions.reinstall.confirmtitle   = Remover Pack
 modpackoptions.reinstall.cannottitle    = Impossível reinstalar
 modpackoptions.reinstall.cannotoffline  = Este modpack não pode ser reinstalado agora porque está offline
 modpackoptions.move.errortext           = Por favor seleccione uma pasta vazia.
 modpackoptions.move.errortitle          = Localização inválida
 modpackoptions.delete.text              = Eliminar Pack
-modpackoptions.delete.confirmtext       = Tem a certeza que pretende remover este pack do seu sistema?
+modpackoptions.delete.confirmtext       = Tens a certeza que queres remover este pack do teu sistema?
 modpackoptions.delete.confirmtitle      = Eliminar Pack
 modpackoptions.delete.savestext         = Tens a certeza que queres remover este pack do teu sistema?\n\nEste pack tem mundos guardados. Se os mantiveres, os teus mundos voltam se um dia voltares a instalar este pack.
 modpackoptions.delete.deleteeverything  = Eliminar tudo

--- a/src/test/java/net/technicpack/launchercore/modpacks/ModpackModelDeleteTest.java
+++ b/src/test/java/net/technicpack/launchercore/modpacks/ModpackModelDeleteTest.java
@@ -1,0 +1,148 @@
+package net.technicpack.launchercore.modpacks;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.technicpack.launcher.io.InstalledPackStore;
+import net.technicpack.launcher.io.LauncherFileSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ModpackModelDeleteTest {
+
+  private static final String PACK_NAME = "testpack";
+  private static final byte[] WORLD_DATA = {4, 2};
+
+  @TempDir Path tempDir;
+
+  private LauncherFileSystem fileSystem;
+  private InstalledPackStore packStore;
+  private Path packDir;
+  private Path assetsDir;
+
+  @BeforeEach
+  void setUp() {
+    fileSystem = new LauncherFileSystem(tempDir.resolve("launcher-root"));
+    packStore = new InstalledPackStore(tempDir.resolve("installedpacks.json"));
+    packDir = tempDir.resolve("modpacks").resolve(PACK_NAME);
+    assetsDir = fileSystem.getPackAssetsDirectory().resolve(PACK_NAME);
+  }
+
+  private ModpackModel installedModel() throws IOException {
+    Files.createDirectories(packDir.resolve("bin"));
+    Files.createDirectories(packDir.resolve("mods"));
+    Files.createDirectories(packDir.resolve("config"));
+    Files.write(
+        packDir.resolve("config").resolve("some.cfg"),
+        "key=value".getBytes(StandardCharsets.UTF_8));
+    Files.write(packDir.resolve("options.txt"), "fov:0.5".getBytes(StandardCharsets.UTF_8));
+
+    Files.createDirectories(assetsDir);
+    Files.write(assetsDir.resolve("background.png"), new byte[] {1, 2, 3});
+
+    InstalledPack pack =
+        new InstalledPack(PACK_NAME, InstalledPack.RECOMMENDED, packDir.toString());
+    packStore.put(pack);
+
+    return new ModpackModel(pack, null, packStore, fileSystem);
+  }
+
+  private void addWorldSave() throws IOException {
+    Path worldDir = packDir.resolve("saves").resolve("MyWorld");
+    Files.createDirectories(worldDir);
+    Files.write(worldDir.resolve("level.dat"), WORLD_DATA);
+  }
+
+  // -------------------------------------------------------------------------
+  // hasWorldSaves
+  // -------------------------------------------------------------------------
+
+  @Test
+  void hasWorldSavesFalseWithoutInstalledDirectory() {
+    InstalledPack pack = new InstalledPack(PACK_NAME, InstalledPack.RECOMMENDED);
+    ModpackModel model = new ModpackModel(pack, null, packStore, fileSystem);
+
+    assertFalse(model.hasWorldSaves());
+  }
+
+  @Test
+  void hasWorldSavesFalseWhenSavesDirMissing() throws IOException {
+    ModpackModel model = installedModel();
+
+    assertFalse(model.hasWorldSaves());
+  }
+
+  @Test
+  void hasWorldSavesFalseWhenSavesDirEmpty() throws IOException {
+    ModpackModel model = installedModel();
+    Files.createDirectories(packDir.resolve("saves"));
+
+    assertFalse(model.hasWorldSaves());
+  }
+
+  @Test
+  void hasWorldSavesTrueWhenSavesDirHasContent() throws IOException {
+    ModpackModel model = installedModel();
+    addWorldSave();
+
+    assertTrue(model.hasWorldSaves());
+  }
+
+  // -------------------------------------------------------------------------
+  // delete
+  // -------------------------------------------------------------------------
+
+  @Test
+  void deleteRemovesEverythingIncludingSaves() throws IOException {
+    ModpackModel model = installedModel();
+    addWorldSave();
+
+    model.delete();
+
+    assertFalse(Files.exists(packDir));
+    assertFalse(Files.exists(assetsDir));
+    assertFalse(packStore.getInstalledPacks().containsKey(PACK_NAME));
+  }
+
+  @Test
+  void deleteKeepingSavesKeepsOnlySaves() throws IOException {
+    ModpackModel model = installedModel();
+    addWorldSave();
+
+    model.delete(true);
+
+    Path levelDat = packDir.resolve("saves").resolve("MyWorld").resolve("level.dat");
+    assertTrue(Files.exists(levelDat));
+    assertArrayEquals(WORLD_DATA, Files.readAllBytes(levelDat));
+
+    try (Stream<Path> children = Files.list(packDir)) {
+      List<Path> remaining = children.collect(Collectors.toList());
+      assertEquals(Collections.singletonList(packDir.resolve("saves")), remaining);
+    }
+
+    assertFalse(Files.exists(assetsDir));
+    assertFalse(packStore.getInstalledPacks().containsKey(PACK_NAME));
+  }
+
+  @Test
+  void deleteKeepingSavesWithoutSavesDirRemovesEverything() throws IOException {
+    ModpackModel model = installedModel();
+
+    model.delete(true);
+
+    assertFalse(Files.exists(packDir));
+    assertFalse(Files.exists(assetsDir));
+    assertFalse(packStore.getInstalledPacks().containsKey(PACK_NAME));
+  }
+}


### PR DESCRIPTION
## Summary

Deleting a modpack used to silently wipe the whole pack directory, including `saves/`. Now, when the pack has world saves, both delete buttons (modpack page and pack options dialog) show a three-button warning dialog: **Delete everything** / **Keep world saves** / **Cancel** (default Cancel, Esc cancels).

Keeping saves deletes everything except `saves/`, which stays in place. Since pack discovery is registry-based and a reinstall resolves the same slug directory, reinstalling the pack picks the worlds back up automatically. Packs without saves (the check requires actual content, since `initDirectories()` creates an empty `saves/` for every install) keep the plain yes/no confirmation.

## Implementation notes

- `ModpackModel.delete(boolean keepSaves)` overload; no-arg `delete()` delegates unchanged. The saves-folder name check is case-insensitive so a differently-cased `Saves` on Windows/macOS isn't destroyed.
- New `ModpackDeleteDialog.confirmDelete(...)` deduplicates the two previously copy-pasted confirm blocks; the modpack-page path gains the warning icon the options dialog already used.
- New strings in `UIText_en.properties` (base-bundle fallback covers all locales) plus pt-PT/pt-BR translations in the informal register, including a re-tone of the two existing formal pt-PT confirmations in the same flow.

## Testing

- 7 new unit tests for `hasWorldSaves()` / both delete modes (`ModpackModelDeleteTest`)
- `./gradlew spotlessApply check` green (267 test cases)
- Manual end-to-end pass: keep → reinstall → worlds restored; delete-everything; empty-saves fallback dialog; both entry points